### PR TITLE
Change use of version_compare filter to version

### DIFF
--- a/meta/main.yml
+++ b/meta/main.yml
@@ -4,7 +4,7 @@ galaxy_info:
   description: Role to maintain and configure the SSH daemon
   company: systemli.org
   license: GPLv3
-  min_ansible_version: 2.2
+  min_ansible_version: 2.5
   galaxy_tags:
     - system
     - networking

--- a/templates/sshd_config.j2
+++ b/templates/sshd_config.j2
@@ -149,7 +149,7 @@ AllowUsers {{ sshd_allow_users|join(" ") }}
 AllowGroups {{ sshd_allow_groups|join(" ") }}
 {% endif %}
 
-{% if ansible_distribution == 'Debian' or (ansible_distribution == 'Ubuntu' and ansible_distribution_version | version_compare('14.04', '>' )) %}
+{% if ansible_distribution == 'Debian' or (ansible_distribution == 'Ubuntu' and ansible_distribution_version is version('14.04', '>' )) %}
 # Specifies whether to remove an existing Unix-domain socket file for
 # local or remote port forwarding before creating a new one.
 StreamLocalBindUnlink {{ sshd_stream_local_bind_unlink }}


### PR DESCRIPTION
Ansible 2.9.0 throws "AnsibleError: template error while templating string: no filter named 'version_compare'". The version_compare filter was removed in 2.9 after being deprecated in 2.5.

See https://github.com/geerlingguy/ansible-role-varnish/issues/90